### PR TITLE
Use built-in Netlify action for setup

### DIFF
--- a/.github/workflows/deploy-netlify-on-pr.yml
+++ b/.github/workflows/deploy-netlify-on-pr.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Netlify CLI
-        run: npm install -g netlify-cli
+      - name: Setup Netlify CLI
+        uses: netlify/actions/cli@v2
+        with:
+          cli-version: 'latest'
 
       - name: Deploy to Netlify (Preview)
         id: netlify


### PR DESCRIPTION
Replace manual installation of the Netlify CLI with the built-in GitHub action for a more streamlined deployment process.